### PR TITLE
Add Spring Boot Taskana wrapper example

### DIFF
--- a/spring-boot-taskana-wrapper/Dockerfile
+++ b/spring-boot-taskana-wrapper/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:17-jdk-slim
+COPY target/taskana-spring-boot.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/spring-boot-taskana-wrapper/pom.xml
+++ b/spring-boot-taskana-wrapper/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>taskana-spring-boot</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <taskana.version>5.8.0</taskana.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>pro.taskana</groupId>
+            <artifactId>taskana-core</artifactId>
+            <version>${taskana.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/Application.java
+++ b/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/Application.java
@@ -1,0 +1,11 @@
+package com.example.taskana;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/TaskProducer.java
+++ b/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/TaskProducer.java
@@ -1,0 +1,26 @@
+package com.example.taskana;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import pro.taskana.TaskanaEngine;
+import pro.taskana.task.api.models.Task;
+import pro.taskana.task.api.TaskService;
+
+@Component
+public class TaskProducer implements CommandLineRunner {
+
+    private final TaskService taskService;
+
+    public TaskProducer(TaskanaEngine taskanaEngine) {
+        this.taskService = taskanaEngine.getTaskService();
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        Task task = taskService.newTask("USER_1");
+        task.setName("Sample Task");
+        taskService.createTask(task);
+        System.out.println("Created task: " + task.getId());
+    }
+}

--- a/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/TaskanaConfig.java
+++ b/spring-boot-taskana-wrapper/src/main/java/com/example/taskana/TaskanaConfig.java
@@ -1,0 +1,18 @@
+package com.example.taskana;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import javax.sql.DataSource;
+
+import pro.taskana.TaskanaEngine;
+import pro.taskana.TaskanaEngineConfiguration;
+
+@Configuration
+public class TaskanaConfig {
+
+    @Bean
+    public TaskanaEngine taskanaEngine(DataSource dataSource) throws Exception {
+        TaskanaEngineConfiguration configuration = new TaskanaEngineConfiguration(dataSource, false, false);
+        return configuration.buildTaskanaEngine();
+    }
+}

--- a/spring-boot-taskana-wrapper/src/main/resources/application.properties
+++ b/spring-boot-taskana-wrapper/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/taskanadb
+spring.datasource.username=taskana
+spring.datasource.password=taskana
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=none

--- a/spring-boot-taskana-wrapper/src/test/java/com/example/taskana/TaskCreationTest.java
+++ b/spring-boot-taskana-wrapper/src/test/java/com/example/taskana/TaskCreationTest.java
@@ -1,0 +1,28 @@
+package com.example.taskana;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.models.Task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DirtiesContext
+class TaskCreationTest {
+
+    @Autowired
+    private TaskService taskService;
+
+    @Test
+    void testTaskCreation() throws Exception {
+        Task task = taskService.newTask("USER_1");
+        task.setName("JUnit Task");
+        Task created = taskService.createTask(task);
+        Task found = taskService.getTask(created.getId());
+        assertThat(found).isNotNull();
+    }
+}

--- a/spring-boot-taskana-wrapper/src/test/resources/application.properties
+++ b/spring-boot-taskana-wrapper/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- add a `taskana-spring-boot` sample app using Taskana core and Postgres
- include integration test using an in-memory database
- provide a Dockerfile for running the app

## Testing
- `mvn -q -pl spring-boot-taskana-wrapper test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685855b0a674832e8b6aae3c6b9354ba